### PR TITLE
Fix xava.desktop path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,4 +219,4 @@ target_link_libraries(xava ${ADDITIONAL_LIBRARIES} m ${FFTW3_LIBRARIES} pthread 
 # Install
 install (TARGETS xava DESTINATION bin)
 install (FILES LICENSE DESTINATION share/licenses/xava)
-install (FILES assets/desktop/xava.desktop DESTINATION share/applications)
+install (FILES assets/linux/xava.desktop DESTINATION share/applications)


### PR DESCRIPTION
Error when running `make install` as the path to `xava.desktop` is wrong.

Reproduction:

```sh
git clone --depth 1 https://github.com/nikp123/xava && \
  git clone --depth 1 https://github.com/ndevilla/iniparser xava/lib/iniparser && \
  mkdir xava/build && \
  cd xava/build && \
  cmake .. -DCMAKE_BUILD_TYPE=Release -DINCLUDE_DIRS=lib/iniparser/src && \
  make -j$(nproc) && \
  make install
``` 