### PR TITLE
[fix] output/x11: fix incorrect screen change query condition

### DIFF
--- a/src/output/graphical_x.c
+++ b/src/output/graphical_x.c
@@ -491,7 +491,7 @@ int get_window_input_x(void) {
 					return -1;
 				break;
 			default:
-				if(xavaRREventBase + RRScreenChangeNotify) {
+				if(xavaRREventBase && RRScreenChangeNotify) {
 					printf("Display change detected - Restarting...\n");
 					return 1;
 				}


### PR DESCRIPTION
This fixes #20 , but I don't have multiple monitors, so let me know if it works for the original usecase.