### PR TITLE
GetInstallDir: fix buffer overflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,49 @@
+language: cpp
+
+dist: bionic
+
+matrix:
+    include:
+      - os: linux
+        compiler: gcc
+        addons:
+          apt:
+            update: true
+            packages:
+              - libfftw3-dev
+              - libasound2-dev
+              - libpulse-dev
+              - libx11-dev
+              - libsdl2-dev
+              - portaudio19-dev
+              - cmake
+              - git
+        cache: ccache
+
+git:
+ depth: false
+ submodules: true
+
+script:
+ - mkdir build
+ - cd build
+ - cmake -DCMAKE_BUILD_TYPE=Release -DSHMEM=ON ..
+ - make
+ - make clean
+ - cmake -DCMAKE_BUILD_TYPE=Release -DSDL2=ON -DX11=OFF -DALSA=OFF -DPULSEAUDIO=OFF -DSNDIO=OFF -DPORTAUDIO=OFF ..
+ - make
+ - make clean
+ - cmake -DCMAKE_BUILD_TYPE=Release -DSDL2=OFF -DX11=ON -DALSA=OFF -DPULSEAUDIO=OFF -DSNDIO=OFF -DPORTAUDIO=OFF ..
+ - make
+ - make clean
+ - cmake -DCMAKE_BUILD_TYPE=Release -DSDL2=ON -DX11=OFF -DALSA=ON -DPULSEAUDIO=OFF -DSNDIO=OFF -DPORTAUDIO=OFF ..
+ - make
+ - make clean
+ - cmake -DCMAKE_BUILD_TYPE=Release -DSDL2=ON -DX11=OFF -DALSA=OFF -DPULSEAUDIO=ON -DSNDIO=OFF -DPORTAUDIO=OFF ..
+ - make
+ - make clean
+ - cmake -DCMAKE_BUILD_TYPE=Release -DSDL2=ON -DX11=OFF -DALSA=OFF -DPULSEAUDIO=OFF -DSNDIO=ON -DPORTAUDIO=OFF ..
+ - make
+ - make clean
+ - cmake -DCMAKE_BUILD_TYPE=Release -DSDL2=ON -DX11=OFF -DALSA=OFF -DPULSEAUDIO=OFF -DSNDIO=OFF -DPORTAUDIO=ON ..
+ - make

--- a/src/shared.c
+++ b/src/shared.c
@@ -107,7 +107,7 @@ char *xavaGetInstallDir() {
 		path[strlen(path)-executableNameSize] = '\0';
 	#else 
 		// everything non-windows is simple as fuck, go look at the mess above
-		const char *path = malloc(strlen(PREFIX"/share/"PACKAGE"/"));
+		const char *path = malloc(strlen(PREFIX"/share/"PACKAGE"/") + 1);
 		strcpy(path, PREFIX"/share/"PACKAGE"/");
 	#endif
 	return path;


### PR DESCRIPTION
strlen(3) will return length of input, not including terminating NUL
character. And strcpy(3) will copy the included NUL character.
Thus, we'll get buffer overflow for 1 character.

Fix it.