### PR TITLE
Bring a performance boost to monstercat_filter

### DIFF
--- a/src/xava.c
+++ b/src/xava.c
@@ -186,7 +186,7 @@ void monstercat_filter(int bars, int waves, double monstercat, int *data) {
 			}
 		}
 	} else if (monstercat > 0) {
-		for (z = 0; z < bars; z++) {
+		for (z = 0; z < (bars/3); z++) {
 			//if (f[z] < 1)f[z] = 1;
 			for (m_y = z - 1; m_y >= 0; m_y--) {
 				de = z - m_y;


### PR DESCRIPTION
This change should bring a performance boost to monstercat_filter by only calculating 1/3 of the bars' values since the rest is not visible, the theoretical performance boost should be +200%.